### PR TITLE
Update to nom 6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ homepage = "https://github.com/myfreeweb/devd-rs"
 repository = "https://github.com/myfreeweb/devd-rs"
 
 [dependencies]
-nom = { version = "5", default-features = false, features = ["std"] }
+nom = { version = "6", default-features = false, features = ["std"] }
 libc = "0"


### PR DESCRIPTION
This PR updates `devd-rs` to use use Nom 6 instead of 5 to stay inline with the rest of the Rust ecosystem.

If not inconvenient, a patch release would be appreciated of `0.3.2`. The only non-transparent change for end users is that the MSRV of Nom went to Rust 1.44, but I don't see a MSRV for this crate.