### PR TITLE
Update to nom 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ license = "Unlicense/MIT"
 readme = "README.md"
 homepage = "https://github.com/unrelentingtech/devd-rs"
 repository = "https://github.com/unrelentingtech/devd-rs"
+edition = "2018"
 
 [dependencies]
-nom = { version = "6", default-features = false, features = ["std"] }
 libc = "0"
+nom = { version = "7", default-features = false, features = ["std"] }
+nom-supreme = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ pub use result::*;
 
 const SOCKET_PATH: &str = "/var/run/devd.seqpacket.pipe";
 
-pub fn parse_devd_event(e: String) -> Result<Event> {
-    match parser::event(e.as_str()) {
+pub fn parse_devd_event(event: &str) -> Result<Event> {
+    match parser::event(event) {
         Ok((_, x)) => Ok(x),
         _ => Err(Error::Parse),
     }
@@ -25,6 +25,7 @@ pub fn parse_devd_event(e: String) -> Result<Event> {
 pub struct Context {
     sock: BufReader<UnixStream>,
     sockfd: RawFd,
+    buffer: String,
 }
 
 impl Context {
@@ -44,29 +45,37 @@ impl Context {
             {
                 return Err(io::Error::last_os_error().into());
             }
-            Ok(Context { sock: BufReader::new(UnixStream::from_raw_fd(sockfd)), sockfd })
+            Ok(Context {
+                sock: BufReader::new(UnixStream::from_raw_fd(sockfd)),
+                sockfd,
+                buffer: String::new(),
+            })
         }
     }
 
-    /// Waits for an event using poll(), reads it but does not parse
-    pub fn wait_for_event_raw(&mut self, timeout_ms: usize) -> Result<String> {
-        let mut fds = vec![pollfd { fd: self.sockfd, events: POLLIN, revents: 0 }];
+    pub fn wait_for_event_raw_internal(&mut self, timeout_ms: usize) -> Result<&str> {
+        let mut fds = [pollfd { fd: self.sockfd, events: POLLIN, revents: 0 }];
         let x = unsafe { poll((&mut fds).as_mut_ptr(), fds.len() as nfds_t, timeout_ms as c_int) };
 
         match x.cmp(&0) {
             Ordering::Less => Err(io::Error::last_os_error().into()),
             Ordering::Equal => Err(Error::Timeout),
             Ordering::Greater => {
-                let mut s = String::new();
-                let _ = self.sock.read_line(&mut s);
-                Ok(s)
+                self.buffer.clear();
+                self.sock.read_line(&mut self.buffer)?;
+                Ok(&self.buffer)
             }
         }
     }
 
+    /// Waits for an event using poll(), reads it but does not parse
+    pub fn wait_for_event_raw(&mut self, timeout_ms: usize) -> Result<String> {
+        self.wait_for_event_raw_internal(timeout_ms).map(ToOwned::to_owned)
+    }
+
     /// Waits for an event using poll(), reads and parses it
     pub fn wait_for_event(&mut self, timeout_ms: usize) -> Result<Event> {
-        self.wait_for_event_raw(timeout_ms).and_then(parse_devd_event)
+        self.wait_for_event_raw_internal(timeout_ms).and_then(parse_devd_event)
     }
 
     /// Returns the devd socket file descriptor in case you want to select/poll on it together with
@@ -77,8 +86,8 @@ impl Context {
 
     /// Reads an event and parses it. Use when polling on the raw fd by yourself
     pub fn read_event(&mut self) -> Result<Event> {
-        let mut s = String::new();
-        let _ = self.sock.read_line(&mut s);
-        parse_devd_event(s)
+        self.buffer.clear();
+        self.sock.read_line(&mut self.buffer)?;
+        parse_devd_event(&self.buffer)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,10 @@
-extern crate libc;
-#[macro_use]
-extern crate nom;
-
 pub mod data;
 pub mod parser;
 pub mod result;
 
 use io::{BufRead, BufReader};
 use libc::{c_int, connect, nfds_t, poll, pollfd, sockaddr_un, socket, AF_UNIX, POLLIN, SOCK_SEQPACKET};
+use std::cmp::Ordering;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::{io, mem, ptr};
@@ -15,7 +12,7 @@ use std::{io, mem, ptr};
 pub use data::*;
 pub use result::*;
 
-const SOCKET_PATH: &'static str = "/var/run/devd.seqpacket.pipe";
+const SOCKET_PATH: &str = "/var/run/devd.seqpacket.pipe";
 
 pub fn parse_devd_event(e: String) -> Result<Event> {
     match parser::event(e.as_str()) {
@@ -39,13 +36,15 @@ impl Context {
             }
             let mut sockaddr = sockaddr_un { sun_family: AF_UNIX as _, ..mem::zeroed() };
             ptr::copy_nonoverlapping(SOCKET_PATH.as_ptr(), sockaddr.sun_path.as_mut_ptr() as *mut u8, SOCKET_PATH.len());
-            if connect(sockfd, &sockaddr as *const sockaddr_un as *const _, (mem::size_of_val(&AF_UNIX) + SOCKET_PATH.len()) as _) < 0 {
+            if connect(
+                sockfd,
+                &sockaddr as *const sockaddr_un as *const _,
+                (mem::size_of_val(&AF_UNIX) + SOCKET_PATH.len()) as _,
+            ) < 0
+            {
                 return Err(io::Error::last_os_error().into());
             }
-            Ok(Context {
-                sock: BufReader::new(UnixStream::from_raw_fd(sockfd)),
-                sockfd: sockfd,
-            })
+            Ok(Context { sock: BufReader::new(UnixStream::from_raw_fd(sockfd)), sockfd })
         }
     }
 
@@ -53,19 +52,20 @@ impl Context {
     pub fn wait_for_event_raw(&mut self, timeout_ms: usize) -> Result<String> {
         let mut fds = vec![pollfd { fd: self.sockfd, events: POLLIN, revents: 0 }];
         let x = unsafe { poll((&mut fds).as_mut_ptr(), fds.len() as nfds_t, timeout_ms as c_int) };
-        if x < 0 {
-            Err(io::Error::last_os_error().into())
-        } else if x == 0 {
-            Err(Error::Timeout)
-        } else {
-            let mut s = String::new();
-            let _ = self.sock.read_line(&mut s);
-            Ok(s)
+
+        match x.cmp(&0) {
+            Ordering::Less => Err(io::Error::last_os_error().into()),
+            Ordering::Equal => Err(Error::Timeout),
+            Ordering::Greater => {
+                let mut s = String::new();
+                let _ = self.sock.read_line(&mut s);
+                Ok(s)
+            }
         }
     }
 
     /// Waits for an event using poll(), reads and parses it
-    pub fn wait_for_event<'a>(&mut self, timeout_ms: usize) -> Result<Event> {
+    pub fn wait_for_event(&mut self, timeout_ms: usize) -> Result<Event> {
         self.wait_for_event_raw(timeout_ms).and_then(parse_devd_event)
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,85 +1,82 @@
-use data::*;
-use nom::branch::alt;
-use nom::bytes::complete::take_while;
-use nom::character::complete::{alphanumeric1, char, multispace1};
-use nom::sequence::delimited;
+use crate::data::*;
 
-fn val(i: &str) -> nom::IResult<&str, &str> {
-    alt((delimited(char('"'), take_while(|c| c != '"'), char('"')), take_while(|c| c != '\n' && c != ' ')))(i)
+use nom::{
+    branch::alt,
+    bytes::complete::take_while,
+    character::complete::{alphanumeric1, char, multispace0, multispace1},
+    combinator::success,
+    multi::fold_many0,
+    sequence::tuple,
+    IResult, Parser,
+};
+use nom_supreme::{tag::complete::tag, ParserExt};
+
+/// Parse a single value, which is either a quoted string, or a word without whitespace
+fn val(input: &str) -> IResult<&str, &str, ()> {
+    alt((take_while(|c| c != '"').delimited_by(char('"')), take_while(|c| c != '\n' && c != ' '))).parse(input)
 }
 
-named!(keyval <&str, (&str, &str)>,
-   do_parse!(
-           key: alphanumeric1
-        >> char!('=')
-        >> val: val
-        >> (key, val)
-        )
-    );
+/// Parse a key followed by a value, separated by =
+fn keyval(input: &str) -> IResult<&str, (&str, &str), ()> {
+    alphanumeric1.terminated(char('=')).and(val).parse(input)
+}
 
-named!(keyvals <&str, BTreeMap<String, String> >,
-       map!(
-           many0!(terminated!(keyval, opt!(multispace1))),
-           |vec: Vec<_>| vec.into_iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
-       )
-      );
+/// Parser any number of key-value pairs, separated by 0 or more whitespace
+fn keyvals(input: &str) -> IResult<&str, BTreeMap<String, String>, ()> {
+    fold_many0(keyval.terminated(multispace0), BTreeMap::new, |mut map, (key, value)| {
+        map.insert(key.to_owned(), value.to_owned());
+        map
+    })
+    .parse(input)
+}
 
-named!(pub event <&str, Event>,
-    alt!(
-        do_parse!(
-            tag!("!") >>
-            tag!("system=") >>
-            sys: val >>
-            multispace1 >>
-            tag!("subsystem=") >>
-            subsys: val >>
-            multispace1 >>
-            tag!("type=") >>
-            kind: val >>
-            multispace1 >>
-            data: keyvals >>
-            (Event::Notify { system: sys.to_string(), subsystem: subsys.to_string(), kind: kind.to_string(), data: data })
-        )
-        |
-        do_parse!(
-            tag!("+") >>
-            dev: alphanumeric1 >>
-            multispace1 >>
-            tag!("at") >>
-            multispace1 >>
-            parent: keyvals >>
-            tag!("on") >>
-            multispace1 >>
-            loc: val >>
-            (Event::Attach { dev: dev.to_string(), parent: parent, location: loc.to_string() })
-        )
-        |
-        do_parse!(
-            tag!("-") >>
-            dev: alphanumeric1 >>
-            multispace1 >>
-            tag!("at") >>
-            multispace1 >>
-            parent: keyvals >>
-            tag!("on") >>
-            multispace1 >>
-            loc: val >>
-            (Event::Detach { dev: dev.to_string(), parent: parent, location: loc.to_string() })
-        )
-        |
-        do_parse!(
-            tag!("?") >>
-            multispace1 >>
-            tag!("at") >>
-            multispace1 >>
-            parent: keyvals >>
-            tag!("on") >>
-            multispace1 >>
-            loc: val >>
-            (Event::Nomatch { parent: parent, location: loc.to_string() })
-        )
-    )
-);
+/// Parse a key-value pair, where the key is a specific tag, separated by =,
+/// terminated by whitespace
+fn keyed_val<'i>(key: &'static str) -> impl Parser<&'i str, &'i str, ()> {
+    tag(key).terminated(char('=')).precedes(val).terminated(multispace1)
+}
+
+fn notify(input: &str) -> IResult<&str, Event, ()> {
+    tuple((keyed_val("system"), keyed_val("subsystem"), keyed_val("type"), keyvals))
+        .preceded_by(char('!'))
+        .map(|(sys, subsys, kind, data)| Event::Notify {
+            system: sys.to_owned(),
+            subsystem: subsys.to_owned(),
+            kind: kind.to_owned(),
+            data,
+        })
+        .parse(input)
+}
+
+/// Parse a key-value pair, where the key is a specific tag, separated by
+/// whitespace
+fn event_param<'i, T>(key: &'static str, value: impl Parser<&'i str, T, ()>) -> impl Parser<&'i str, T, ()> {
+    tag(key).terminated(multispace1).precedes(value)
+}
+
+fn generic_event<'i, T>(prefix: char, dev: impl Parser<&'i str, T, ()>) -> impl Parser<&'i str, (T, BTreeMap<String, String>, &'i str), ()> {
+    tuple((
+        char(prefix).precedes(dev).terminated(multispace1),
+        event_param("at", keyvals),
+        event_param("on", val),
+    ))
+}
+
+fn attach(input: &str) -> IResult<&str, Event, ()> {
+    generic_event('+', alphanumeric1).map(|(dev, parent, loc)| Event::Attach { dev: dev.to_owned(), parent, location: loc.to_owned() }).parse(input)
+}
+
+fn detach(input: &str) -> IResult<&str, Event, ()> {
+    generic_event('-', alphanumeric1).map(|(dev, parent, loc)| Event::Detach { dev: dev.to_owned(), parent, location: loc.to_owned() }).parse(input)
+}
+
+fn nomatch(input: &str) -> IResult<&str, Event, ()> {
+    generic_event('?', success(())).map(|((), parent, loc)| Event::Nomatch { parent, location: loc.to_owned() }).parse(input)
+}
+
+pub fn event(input: &str) -> IResult<&str, Event, ()> {
+    alt((notify, attach, detach, nomatch)).parse(input)
+}
 
 #[cfg(test)]
 mod tests {
@@ -102,7 +99,7 @@ mod tests {
                     system: "USB".to_owned(),
                     subsystem: "INTERFACE".to_owned(),
                     kind: "ATTACH".to_owned(),
-                    data: data,
+                    data,
                 }
             ))
         )
@@ -139,7 +136,7 @@ mod tests {
                 "",
                 Event::Detach {
                     dev: "uhid1".to_owned(),
-                    parent: data.to_owned(),
+                    parent: data,
                     location: "uhub1".to_owned(),
                 }
             ))

--- a/src/result.rs
+++ b/src/result.rs
@@ -7,9 +7,9 @@ pub enum Error {
     Parse,
 }
 
-impl Into<io::Error> for Error {
-    fn into(self) -> io::Error {
-        match self {
+impl From<Error> for io::Error {
+    fn from(val: Error) -> Self {
+        match val {
             Error::IoError(e) => e,
             Error::Timeout => io::Error::new(io::ErrorKind::Other, "devd poll timeout"),
             Error::Parse => io::Error::new(io::ErrorKind::Other, "devd parse error"),


### PR DESCRIPTION
- Upgrade to nom 7
    - Replace macro versions of parsers with combinators
    - use nom-supreme for method-chaining combinators
- Various minor updates for clippy
- Update to edition 2018

These changes are all fully backwards compatible, except that they might increase the MSRV. I didn't see any documented MSRV policy so I assumed this was alright.